### PR TITLE
Execution context fix

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.2.1
+version = 3.3.1
 style = defaultWithAlign
 docstrings.style = Asterisk
 runner.dialect=scala213source3

--- a/README.markdown
+++ b/README.markdown
@@ -220,9 +220,9 @@ In short, what you would usually do is:
 ```scala
 import com.github.mauricio.async.db.postgresql.PostgreSQLConnection
 import com.github.mauricio.async.db.postgresql.util.URLParser
-import com.github.mauricio.async.db.util.ExecutorServiceUtils.CachedExecutionContext
 import com.github.mauricio.async.db.{RowData, QueryResult, Connection}
 import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global // Or use the default pool provided by underlying runtime.
 import scala.concurrent.{Await, Future}
 
 object BasicExample {
@@ -245,7 +245,7 @@ object BasicExample {
     }
     )
 
-    val result = Await.result( mapResult, 5 seconds )
+    val result = Await.result( mapResult, 5 seconds ) // Blocking here, used for demo, should be avoid in real application.
 
     println(result)
 

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ lazy val mysql = (project in file("mysql-async"))
 def commonDependencies(scalaVersion: String) = Seq(
   "org.slf4j"                % "slf4j-api"               % "1.7.32",
   "joda-time"                % "joda-time"               % "2.10.13",
-  "org.joda"                 % "joda-convert"            % "2.2.1",
+  "org.joda"                 % "joda-convert"            % "2.2.2",
   "io.netty"                 % "netty-codec"             % nettyVersion,
   "io.netty"                 % "netty-handler"           % nettyVersion,
   "org.javassist"            % "javassist"               % "3.28.0-GA",

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,25 @@ def testDependency(scalaVersion: String) = {
   )
 }
 
+def scalaVersionSpecificFolders(
+  srcName: String,
+  srcBaseDir: java.io.File,
+  scalaVersion: String
+) = {
+  println(srcBaseDir)
+  def extraDirs(suffix: String) =
+    srcBaseDir / "src" / srcName / s"scala${suffix}"
+
+  CrossVersion.partialVersion(scalaVersion) match {
+    case Some((2, y)) =>
+      val shared2x = extraDirs("-2.x")
+      val extra    = if (y >= 13) extraDirs("-2.13+") else extraDirs("-2.13-")
+      Seq(shared2x, extra)
+    case Some((0 | 3, _)) => Seq(extraDirs("-2.13+"), extraDirs("-3.x"))
+    case _                => Nil
+  }
+}
+
 lazy val root = (project in file("."))
   .settings(baseSettings: _*)
   .settings(
@@ -24,11 +43,11 @@ lazy val root = (project in file("."))
   .aggregate(common, postgresql, mysql)
 
 lazy val common = (project in file("db-async-common"))
-  .settings(baseSettings: _*)
   .settings(
     name := commonName,
     libraryDependencies ++= commonDependencies(scalaVersion.value)
   )
+  .settings(baseSettings: _*)
 
 lazy val postgresql = (project in file("postgresql-async"))
   .settings(baseSettings: _*)
@@ -89,6 +108,16 @@ val baseSettings = Seq(
   (Test / javaOptions) ++= Seq(
     "-Dio.netty.leakDetection.level=paranoid",
     "-Dorg.slf4j.simpleLogger.log.io.netty=DEBUG"
+  ),
+  Compile / unmanagedSourceDirectories ++= scalaVersionSpecificFolders(
+    "main",
+    baseDirectory.value,
+    scalaVersion.value
+  ),
+  Test / unmanagedSourceDirectories ++= scalaVersionSpecificFolders(
+    "test",
+    baseDirectory.value,
+    scalaVersion.value
   ),
   organization               := "com.github.postgresql-async",
   (Test / parallelExecution) := false

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,6 @@ def scalaVersionSpecificFolders(
   srcBaseDir: java.io.File,
   scalaVersion: String
 ) = {
-  println(srcBaseDir)
   def extraDirs(suffix: String) =
     srcBaseDir / "src" / srcName / s"scala${suffix}"
 

--- a/db-async-common/src/main/scala-2.13+/com/github/mauricio/async/db/util/SameThreadExecutionContext.scala
+++ b/db-async-common/src/main/scala-2.13+/com/github/mauricio/async/db/util/SameThreadExecutionContext.scala
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.github.mauricio.async.db.util
+
+import scala.concurrent.ExecutionContext
+
+private[util] object SameThreadExecutionContext {
+  def apply(): ExecutionContext = ExecutionContext.parasitic
+}

--- a/db-async-common/src/main/scala-2.13-/com/github/mauricio/async/db/util/BatchExecutor.scala
+++ b/db-async-common/src/main/scala-2.13-/com/github/mauricio/async/db/util/BatchExecutor.scala
@@ -1,0 +1,107 @@
+package com.github.mauricio.async.db.util
+
+import java.util.ArrayDeque
+import java.util.concurrent.Executor
+import scala.annotation.tailrec
+import scala.concurrent._
+
+private[util] trait BatchingExecutor extends Executor {
+
+  // invariant: if "_tasksLocal.get ne null" then we are inside Batch.run; if it is null, we are outside
+  private[this] val _tasksLocal = new ThreadLocal[AbstractBatch]()
+
+  private[this] abstract class AbstractBatch
+      extends ArrayDeque[Runnable](4)
+      with Runnable {
+    @tailrec final def processBatch(batch: AbstractBatch): Unit =
+      if ((batch eq this) && !batch.isEmpty) {
+        batch.poll().run()
+        processBatch(
+          _tasksLocal.get
+        ) // If this is null, then we have been using managed blocking, so bail out
+      }
+
+    protected final def resubmitUnbatched(): Boolean = {
+      val current = _tasksLocal.get()
+      _tasksLocal.remove()
+      if ((current eq this) && !current.isEmpty) { // Resubmit ourselves if something bad happened and we still have work to do
+        unbatchedExecute(current) // TODO what if this submission fails?
+        true
+      } else false
+    }
+  }
+
+  private[this] final class Batch extends AbstractBatch {
+    override final def run: Unit = {
+      require(_tasksLocal.get eq null)
+      _tasksLocal.set(this) // Install ourselves as the current batch
+      try processBatch(this)
+      catch {
+        case t: Throwable =>
+          resubmitUnbatched()
+          throw t
+      } finally _tasksLocal.remove()
+    }
+  }
+
+  private[this] val _blockContext = new ThreadLocal[BlockContext]()
+
+  private[this] final class BlockableBatch
+      extends AbstractBatch
+      with BlockContext {
+    // this method runs in the delegate ExecutionContext's thread
+    override final def run(): Unit = {
+      require(_tasksLocal.get eq null)
+      _tasksLocal.set(this) // Install ourselves as the current batch
+      val firstInvocation = _blockContext.get eq null
+      if (firstInvocation) _blockContext.set(BlockContext.current)
+      BlockContext.withBlockContext(this) {
+        try processBatch(this)
+        catch {
+          case t: Throwable =>
+            resubmitUnbatched()
+            throw t
+        } finally {
+          _tasksLocal.remove()
+          if (firstInvocation) _blockContext.remove()
+        }
+      }
+    }
+
+    override def blockOn[T](thunk: => T)(implicit permission: CanAwait): T = {
+      // if we know there will be blocking, we don't want to keep tasks queued up because it could deadlock.
+      resubmitUnbatched()
+      // now delegate the blocking to the previous BC
+      _blockContext.get.blockOn(thunk)
+    }
+  }
+
+  protected def unbatchedExecute(r: Runnable): Unit
+
+  protected def resubmitOnBlock: Boolean
+
+  override def execute(runnable: Runnable): Unit = {
+    if (batchable(runnable)) { // If we can batch the runnable
+      _tasksLocal.get match {
+        case null =>
+          val newBatch: AbstractBatch =
+            if (resubmitOnBlock) new BlockableBatch() else new Batch()
+          newBatch.add(runnable)
+          unbatchedExecute(
+            newBatch
+          ) // If we aren't in batching mode yet, enqueue batch
+        case batch =>
+          batch.add(
+            runnable
+          ) // If we are already in batching mode, add to batch
+      }
+    } else
+      unbatchedExecute(
+        runnable
+      ) // If not batchable, just delegate to underlying
+  }
+
+  /** Override this to define which runnables will be batched. */
+  def batchable(runnable: Runnable): Boolean =
+    ScalaBatchable.isBatchable(runnable)
+}

--- a/db-async-common/src/main/scala-2.13-/com/github/mauricio/async/db/util/SameThreadExecutionContext.scala
+++ b/db-async-common/src/main/scala-2.13-/com/github/mauricio/async/db/util/SameThreadExecutionContext.scala
@@ -1,0 +1,26 @@
+package com.github.mauricio.async.db.util
+import scala.concurrent.ExecutionContext
+
+/**
+ * Factory to create same thread ec. Not intended to be called from any other
+ * site than to create [[akka.dispatch.ExecutionContexts#parasitic]]
+ *
+ * INTERNAL API
+ */
+private[util] object SameThreadExecutionContext {
+
+  private val sameThread = new ExecutionContext with BatchingExecutor {
+    override protected def unbatchedExecute(runnable: Runnable): Unit =
+      runnable.run()
+    override protected def resubmitOnBlock: Boolean =
+      false // No point since we execute on same thread
+    override def reportFailure(t: Throwable): Unit =
+      throw new IllegalStateException(
+        "exception in sameThreadExecutionContext",
+        t
+      )
+  }
+
+  def apply(): ExecutionContext = sameThread
+
+}

--- a/db-async-common/src/main/scala-2.13-/com/github/mauricio/async/db/util/ScalaBatchable.scala
+++ b/db-async-common/src/main/scala-2.13-/com/github/mauricio/async/db/util/ScalaBatchable.scala
@@ -1,0 +1,11 @@
+package com.github.mauricio.async.db.util
+
+private[util] object ScalaBatchable {
+
+  // see Scala 2.13 source tree for explanation
+  def isBatchable(runnable: Runnable): Boolean = runnable match {
+    case _: scala.concurrent.OnCompleteRunnable => true
+    case _                                      => false
+  }
+
+}

--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/ConnectionPool.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/ConnectionPool.scala
@@ -39,8 +39,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class ConnectionPool[T <: Connection](
   factory: ObjectFactory[T],
   configuration: PoolConfiguration,
-  executionContext: ExecutionContext =
-    ExecutorServiceUtils.CachedExecutionContext
+  executionContext: ExecutionContext = ExecutorServiceUtils.SameThread
 ) extends SingleThreadedAsyncObjectPool[T](factory, configuration)
     with Connection {
 

--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/PartitionedAsyncObjectPool.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/PartitionedAsyncObjectPool.scala
@@ -13,7 +13,7 @@ class PartitionedAsyncObjectPool[T](
   numberOfPartitions: Int
 ) extends AsyncObjectPool[T] {
 
-  import ExecutorServiceUtils.CachedExecutionContext
+  import ExecutorServiceUtils.SameThread
 
   private val pools =
     (0 until numberOfPartitions)

--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/PartitionedConnectionPool.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/PartitionedConnectionPool.scala
@@ -8,8 +8,7 @@ class PartitionedConnectionPool[T <: Connection](
   factory: ObjectFactory[T],
   configuration: PoolConfiguration,
   numberOfPartitions: Int,
-  executionContext: ExecutionContext =
-    ExecutorServiceUtils.CachedExecutionContext
+  executionContext: ExecutionContext = ExecutorServiceUtils.SameThread
 ) extends PartitionedAsyncObjectPool[T](
       factory,
       configuration,

--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/util/ExecutorServiceUtils.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/util/ExecutorServiceUtils.scala
@@ -20,16 +20,11 @@ import java.util.concurrent.{ExecutorService, Executors}
 import scala.concurrent.ExecutionContext
 
 object ExecutorServiceUtils {
-  implicit val CachedThreadPool: ExecutorService =
-    Executors.newCachedThreadPool(DaemonThreadsFactory("db-async-default"))
-
-  implicit val CachedExecutionContext: ExecutionContext =
-    ExecutionContext.fromExecutor(CachedThreadPool)
-
   def newFixedPool(count: Int, name: String): ExecutorService = {
     Executors.newFixedThreadPool(count, DaemonThreadsFactory(name))
   }
 
-  implicit val sameThread = SameThreadExecutionContext()
+  private[db] implicit val SameThread: ExecutionContext =
+    SameThreadExecutionContext()
 
 }

--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/util/ExecutorServiceUtils.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/util/ExecutorServiceUtils.scala
@@ -24,6 +24,12 @@ object ExecutorServiceUtils {
     Executors.newFixedThreadPool(count, DaemonThreadsFactory(name))
   }
 
+  implicit val CachedThreadPool: ExecutorService =
+    Executors.newCachedThreadPool(DaemonThreadsFactory("db-async-default"))
+
+  implicit val CachedExecutionContext: ExecutionContext =
+    ExecutionContext.fromExecutor(CachedThreadPool)
+
   private[db] implicit val SameThread: ExecutionContext =
     SameThreadExecutionContext()
 

--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/util/ExecutorServiceUtils.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/util/ExecutorServiceUtils.scala
@@ -22,11 +22,14 @@ import scala.concurrent.ExecutionContext
 object ExecutorServiceUtils {
   implicit val CachedThreadPool: ExecutorService =
     Executors.newCachedThreadPool(DaemonThreadsFactory("db-async-default"))
+
   implicit val CachedExecutionContext: ExecutionContext =
     ExecutionContext.fromExecutor(CachedThreadPool)
 
   def newFixedPool(count: Int, name: String): ExecutorService = {
     Executors.newFixedThreadPool(count, DaemonThreadsFactory(name))
   }
+
+  implicit val sameThread = SameThreadExecutionContext()
 
 }

--- a/mysql-async/src/main/scala/com/github/mauricio/async/db/mysql/MySQLConnection.scala
+++ b/mysql-async/src/main/scala/com/github/mauricio/async/db/mysql/MySQLConnection.scala
@@ -47,7 +47,7 @@ class MySQLConnection(
   charsetMapper: CharsetMapper = CharsetMapper.Instance,
   group: EventLoopGroup = NettyUtils.DefaultEventLoopGroup,
   implicit val executionContext: ExecutionContext =
-    ExecutorServiceUtils.CachedExecutionContext
+    ExecutorServiceUtils.SameThread
 ) extends MySQLHandlerDelegate
     with Connection
     with TimeoutScheduler {

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/PostgreSQLConnection.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/PostgreSQLConnection.scala
@@ -64,7 +64,7 @@ class PostgreSQLConnection(
     PostgreSQLColumnDecoderRegistry.Instance,
   group: EventLoopGroup = NettyUtils.DefaultEventLoopGroup,
   implicit val executionContext: ExecutionContext =
-    ExecutorServiceUtils.CachedExecutionContext
+    ExecutorServiceUtils.SameThread
 ) extends PostgreSQLConnectionDelegate
     with Connection
     with TimeoutScheduler {

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/column/PostgreSQLColumnEncoderRegistry.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/column/PostgreSQLColumnEncoderRegistry.scala
@@ -122,7 +122,7 @@ class PostgreSQLColumnEncoderRegistry extends ColumnEncoderRegistry {
       value match {
         case i: java.lang.Iterable[_] => encodeArray(i.asScala)
         case i: Iterable[_]           => encodeArray(i)
-        case i: Array[_]              => encodeArray(i.toIterable)
+        case i: Array[_]              => encodeArray(i)
         case p: Product               => encodeComposite(p)
         case _ => {
           this.classesSequence

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/pool/PostgreSQLConnectionFactory.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/pool/PostgreSQLConnectionFactory.scala
@@ -43,8 +43,7 @@ object PostgreSQLConnectionFactory {
 class PostgreSQLConnectionFactory(
   val configuration: Configuration,
   group: EventLoopGroup = NettyUtils.DefaultEventLoopGroup,
-  executionContext: ExecutionContext =
-    ExecutorServiceUtils.CachedExecutionContext
+  executionContext: ExecutionContext = ExecutorServiceUtils.SameThread
 ) extends ObjectFactory[PostgreSQLConnection] {
 
   import PostgreSQLConnectionFactory.log


### PR DESCRIPTION
Previously Cached thread pool is used everywhere. 
Which may cause contention (in ConnectionPool especially).
This pr use the `SameThread` instead. Which will reduce thread creation, context switch, and contetion.