### PR TITLE
Remove connection id from logger for perf

### DIFF
--- a/mysql-async/src/main/scala/com/github/mauricio/async/db/mysql/codec/MySQLConnectionHandler.scala
+++ b/mysql-async/src/main/scala/com/github/mauricio/async/db/mysql/codec/MySQLConnectionHandler.scala
@@ -51,7 +51,7 @@ class MySQLConnectionHandler(
 ) extends SimpleChannelInboundHandler[Object] {
 
   private implicit val internalPool: ExecutionContext = executionContext
-  private final val log = Log.getByName(s"[connection-handler]${connectionId}")
+  private final val log = Log.getByName(s"[connection-handler]")
   private final val bootstrap         = new Bootstrap().group(this.group)
   private final val connectionPromise = Promise[MySQLConnectionHandler]()
   private final val decoder =


### PR DESCRIPTION
**Context**
We transitively use this library extensively in production (via mypipe). Recently after hitting some perf issues, we did some performance profiling and discovered that ~13% of our time was spent waiting on LoggerFactory.getLogger (flame chart images below).

We can see that logback [takes a lock on the root logger object ](https://github.com/qos-ch/logback/blob/ca7fbc7f4c1b1883092037ee4a662034586df07a/logback-classic/src/main/java/ch/qos/logback/classic/LoggerContext.java#L161) when it attempts to create a missing logger. We can also see that the database driver used by mypipe is [creating a new logger on each connection](https://github.com/postgresql-async/postgresql-async/blob/3dd85daf3a3c396385256a09f426ab0dd6d54bdf/mysql-async/src/main/scala/com/github/mauricio/async/db/mysql/codec/MySQLConnectionHandler.scala#L54) to the database. That would be great if we only created one connection per database but we create one connection per MySQLMetadataManager which we restart at least once every 10 minutes (or if there is an alter statement). We suspect that as we accumulate loggers (a small number per each new connection),  adding each subsequent logger becomes more expensive, increasing the time we need to take a lock (and leaking memory but a topic for another day). With age a process will become slower creating connections.

We wrote a micro-benchmark where we create loggers in a loop in several threads to verify my assumption. We can definitely see the overhead of creating a logger increasing with every logger that gets added even with a single creator thread. We can see the overhead grow orders of magnitude as we increase the concurrency. At 128 threads we see that the overhead of adding new loggers can grow to multiple seconds...

<img width="525" alt="image" src="https://github.com/postgresql-async/postgresql-async/assets/39501190/88b41f84-261a-495c-b089-3f06cb4ebe10">

<img width="295" alt="image" src="https://github.com/postgresql-async/postgresql-async/assets/39501190/f7757958-c609-4644-83b1-c2f0093a9904">

<img width="1636" alt="image" src="https://github.com/postgresql-async/postgresql-async/assets/39501190/e3a087c6-7657-4517-96f9-2237b7be6f48">

## The fix
We simply stop adding connection id to the logger name.
