### PR TITLE
Remove connection id from other logger for perf + cleanup

### DIFF
--- a/mysql-async/src/main/scala/com/github/mauricio/async/db/mysql/MySQLConnection.scala
+++ b/mysql-async/src/main/scala/com/github/mauricio/async/db/mysql/MySQLConnection.scala
@@ -65,8 +65,7 @@ class MySQLConnection(
     charsetMapper,
     this,
     group,
-    executionContext,
-    connectionId
+    executionContext
   )
 
   private final val connectionPromise    = Promise[Connection]()

--- a/mysql-async/src/main/scala/com/github/mauricio/async/db/mysql/codec/MySQLFrameDecoder.scala
+++ b/mysql-async/src/main/scala/com/github/mauricio/async/db/mysql/codec/MySQLFrameDecoder.scala
@@ -16,23 +16,22 @@
 
 package com.github.mauricio.async.db.mysql.codec
 
-import com.github.mauricio.async.db.exceptions._
-import com.github.mauricio.async.db.mysql.decoder._
-import com.github.mauricio.async.db.mysql.message.server._
+import com.github.mauricio.async.db.exceptions.*
+import com.github.mauricio.async.db.mysql.decoder.*
+import com.github.mauricio.async.db.mysql.message.server.*
 import com.github.mauricio.async.db.util.ByteBufferUtils.read3BytesInt
 import com.github.mauricio.async.db.util.ChannelWrapper.bufferToWrapper
 import com.github.mauricio.async.db.util.{BufferDumper, Log}
 import io.netty.buffer.ByteBuf
 import io.netty.channel.ChannelHandlerContext
 import io.netty.handler.codec.ByteToMessageDecoder
-import java.nio.ByteOrder
+
 import java.nio.charset.Charset
 import java.util.concurrent.atomic.AtomicInteger
 
-class MySQLFrameDecoder(charset: Charset, connectionId: String)
-    extends ByteToMessageDecoder {
+class MySQLFrameDecoder(charset: Charset) extends ByteToMessageDecoder {
 
-  private final val log = Log.getByName(s"[frame-decoder]${connectionId}")
+  private final val log              = Log.getByName(s"[frame-decoder]")
   private final val messagesCount    = new AtomicInteger()
   private final val handshakeDecoder = new HandshakeV10Decoder(charset)
   private final val errorDecoder     = new ErrorDecoder(charset)

--- a/mysql-async/src/test/scala/com/github/mauricio/async/db/mysql/codec/MySQLFrameDecoderSpec.scala
+++ b/mysql-async/src/test/scala/com/github/mauricio/async/db/mysql/codec/MySQLFrameDecoderSpec.scala
@@ -68,7 +68,7 @@ class MySQLFrameDecoderSpec extends Spec {
 
     "on a query process it should correctly send an OK" in {
 
-      val decoder = new MySQLFrameDecoder(charset, "[mysql-connection]")
+      val decoder = new MySQLFrameDecoder(charset)
       decoder.hasDoneHandshake = true
       val embedder = new EmbeddedChannel(decoder)
       embedder.config.setAllocator(LittleEndianByteBufAllocator.INSTANCE)
@@ -92,7 +92,7 @@ class MySQLFrameDecoderSpec extends Spec {
 
     "on query process it should correctly send an error" in {
 
-      val decoder = new MySQLFrameDecoder(charset, "[mysql-connection]")
+      val decoder = new MySQLFrameDecoder(charset)
       decoder.hasDoneHandshake = true
       val embedder = new EmbeddedChannel(decoder)
       embedder.config.setAllocator(LittleEndianByteBufAllocator.INSTANCE)
@@ -116,7 +116,7 @@ class MySQLFrameDecoderSpec extends Spec {
 
     "on query process it should correctly handle a result set" in {
 
-      val decoder = new MySQLFrameDecoder(charset, "[mysql-connection]")
+      val decoder = new MySQLFrameDecoder(charset)
       decoder.hasDoneHandshake = true
       val embedder = new EmbeddedChannel(decoder)
       embedder.config.setAllocator(LittleEndianByteBufAllocator.INSTANCE)
@@ -181,7 +181,7 @@ class MySQLFrameDecoderSpec extends Spec {
   }
 
   def createPipeline(): EmbeddedChannel = {
-    val decoder = new MySQLFrameDecoder(charset, "[mysql-connection]")
+    val decoder = new MySQLFrameDecoder(charset)
     decoder.hasDoneHandshake = true
     val channel = new EmbeddedChannel(decoder)
     channel.config.setAllocator(LittleEndianByteBufAllocator.INSTANCE)


### PR DESCRIPTION
Adding connectionId to the logger name causes perf issues. See https://github.com/postgresql-async/postgresql-async/pull/187 for full contect.

I missed the other invocation on the last pass, but it showed up on the latest profile
<img width="1648" alt="image" src="https://github.com/postgresql-async/postgresql-async/assets/39501190/d23899bf-f5c6-4adb-b8d2-bf3cc8c58fb9">

